### PR TITLE
AP-9824 # Bumped @oneblink/sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.28.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@oneblink/sdk": "^13.2.2-beta.3",
+        "@oneblink/sdk": "^13.2.3-beta.1",
         "@oneblink/sdk-core": "^10.1.0-beta.1",
         "jsonwebtoken": "^9.0.3"
       },
@@ -2032,13 +2032,13 @@
       }
     },
     "node_modules/@oneblink/sdk": {
-      "version": "13.2.2-beta.3",
-      "resolved": "https://registry.npmjs.org/@oneblink/sdk/-/sdk-13.2.2-beta.3.tgz",
-      "integrity": "sha512-ReoQ7kKpM5xxAu/Yehy5LBkTWyy9GyUiOP5f3Sqc4lwePAYsSqX8kR2hpI+V6VemeTntuUcsaoRh+Z9536wxVQ==",
+      "version": "13.2.3-beta.1",
+      "resolved": "https://registry.npmjs.org/@oneblink/sdk/-/sdk-13.2.3-beta.1.tgz",
+      "integrity": "sha512-wZLsMkQ1ugCWT0wJczE+B3bGBvsLlyMpbtBP4TdQjEgNBHixtbxZERUvBXwGYRNq9AIVrPINIQxXZextbfho/g==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sesv2": "^3.987.0",
-        "@oneblink/sdk-core": "^10.0.0-beta.3",
+        "@oneblink/sdk-core": "^10.1.0-beta.1",
         "@oneblink/storage": "^7.1.2-beta.2",
         "joi": "^18.0.2",
         "jsonwebtoken": "^9.0.3",
@@ -2055,16 +2055,6 @@
       "version": "10.1.0-beta.1",
       "resolved": "https://registry.npmjs.org/@oneblink/sdk-core/-/sdk-core-10.1.0-beta.1.tgz",
       "integrity": "sha512-bk3qfQJPcmUX8gt5gcJnkc2X23k3jVdZ4ynHVXRxf/GhNdP2VrwLJcOsM+z9bQLbf/CWO0NkNh8HMAR08kRhNw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=24",
-        "npm": ">=11"
-      }
-    },
-    "node_modules/@oneblink/sdk/node_modules/@oneblink/sdk-core": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@oneblink/sdk-core/-/sdk-core-10.0.0.tgz",
-      "integrity": "sha512-GxKSKuhK1iKtgQ/8Dc56zt1Wcc7hFBR9Qyy+hdvOchVKdd2HAK/Vj6Snctc45zZyqW9krzfpzBJUCJjwUjcWIw==",
       "license": "MIT",
       "engines": {
         "node": ">=24",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/oneblink/built-in-data-sources/issues"
   },
   "dependencies": {
-    "@oneblink/sdk": "^13.2.2-beta.3",
+    "@oneblink/sdk": "^13.2.3-beta.1",
     "@oneblink/sdk-core": "^10.1.0-beta.1",
     "jsonwebtoken": "^9.0.3"
   },


### PR DESCRIPTION
## Requester Checklist

Please only check the items that you have actioned. Do not check items that are not applicable to your PR.

### Implementation

- [ ] Have you tested your implementation locally?
- [ ] If applicable, has an appropriate changelog entry been added? Do not include if you are fixing/changing something that is only in the current release.
- [ ] There are no warnings that have been suppressed unnecessarily
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
- [ ] Have all OneBlink dependency updates been completed (eg apps / apps-react / types etc).
- [ ] Have you ensured this change does not add unwanted dependencies?
- [ ] If this PR contains a refactor, have relevant Jira testing tasks added?
- [ ] Changes that will knowingly make the feature/bug incomplete have been commented with TODO and a description of what needs to be done to finish the feature/bug
- [ ] Any changes made to public APIs have been reflected in the documentation
- [ ] Have you isolated business logic where possible to allow for unit testing?

### Logging and Debugging

- [ ] Are the error messages, if any, informative?
- [ ] Are there enough log events and are they written in a way that allows for easy debugging?
- [ ] "Debugging" code removed
- [ ] Front-end: No erroneous `Console.WriteLines`

### Readability

- [ ] All class, variable, property and method modifiers are provided with the smallest scope possible
- [ ] New files, variables and functions are descriptive/comprehensible and named consistently.
- [ ] There is no dead code (unreachable code)
- [ ] There is no usage of [magic numbers](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
- [ ] There is no commented out code.
- [ ] In hard-to-understand areas, comments exist and describe rationale or reasons for decisions in code

### Security

- [ ] All personal data inputs are checked (for the correct type, length/size, format, and range).
- [ ] No sensitive information is logged or visible in a stacktrace
- [ ] Are authorization and authentication handled correctly?
- [ ] Is (user) input validated, sanitized, and escaped to prevent security attacks such as cross-site scripting or SQL injection?
- [ ] Is data retrieved from external APIs or libraries checked for security issues?
- [ ] Do API endpoints return appropriate status codes

## Reviewer Guide

- It is important that you understand the purpose of the PR.
- You are encouraged to engage with the requestor if you do not understand any of the proposed code changes/additions/deletions.
- Do you, the reviewer, understand what the code does? Do you think a specific expert, like a security expert or a usability expert, should look over the code before it can be accepted?
- Is a framework, API, library, or service used that should not be used? Are there alternatives you could recommend?
- Are there existing hooks/components/functions in the same code base that could be utilised?
- When reviewing tests, attempt to identify missing edge cases that may be relevant to the proposed implementation
- Ensure you check for:
  - Security
  - Scalability
  - Performance
  - Maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change with no application source edits; risk depends on behavior in the new beta SDK release.
> 
> **Overview**
> Bumps **`@oneblink/sdk`** from `^13.2.2-beta.3` to **`^13.2.3-beta.1`** in `package.json`, with the matching lockfile refresh.
> 
> The resolved tree now pulls **`@oneblink/sdk-core` `^10.1.0-beta.1`** through the SDK (aligned with the existing direct `sdk-core` dependency), so the nested **`node_modules/@oneblink/sdk/node_modules/@oneblink/sdk-core`** copy at `10.0.0` is dropped from the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d94d0baef13816d05ad6c9b679bb2ec1a4de72f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->