### PR TITLE
AP-9991 # Bumped @oneblink/sdk-core, @oneblink/sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.28.0",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@oneblink/sdk": "^13.2.3-beta.7",
-        "@oneblink/sdk-core": "^10.1.0-beta.8",
+        "@oneblink/sdk": "^13.2.3-beta.8",
+        "@oneblink/sdk-core": "^10.1.0-beta.9",
         "jsonwebtoken": "^9.0.3"
       },
       "devDependencies": {
@@ -2032,13 +2032,13 @@
       }
     },
     "node_modules/@oneblink/sdk": {
-      "version": "13.2.3-beta.7",
-      "resolved": "https://registry.npmjs.org/@oneblink/sdk/-/sdk-13.2.3-beta.7.tgz",
-      "integrity": "sha512-pTGF59RDY5DeKHGCficvQRTt9uTyZXHxdx1ifp/Rfxwt66To9r869cTW10hrOGvU+gs572JPU+QdIzNicFPeJw==",
+      "version": "13.2.3-beta.8",
+      "resolved": "https://registry.npmjs.org/@oneblink/sdk/-/sdk-13.2.3-beta.8.tgz",
+      "integrity": "sha512-UIwMJPNhAq5uXIi3KWV95IgGoT46+BlTG1n+SxmvTIVCW9nD3jCPk7OTDa+YTcRLeFW6CWVXsp4I43aeoXoIXQ==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sesv2": "^3.987.0",
-        "@oneblink/sdk-core": "^10.1.0-beta.8",
+        "@oneblink/sdk-core": "^10.1.0-beta.9",
         "@oneblink/storage": "^8.0.0-beta.2",
         "joi": "^18.0.2",
         "jsonwebtoken": "^9.0.3",
@@ -2052,9 +2052,9 @@
       }
     },
     "node_modules/@oneblink/sdk-core": {
-      "version": "10.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@oneblink/sdk-core/-/sdk-core-10.1.0-beta.8.tgz",
-      "integrity": "sha512-1F8xAXagEzEh+U7FE2KLBiquky2uSqVvNFReQz5M/hJqqPLslDZjSpM7thU7UxPBVVZ/lEWD4s3HPD6tTD7Pqw==",
+      "version": "10.1.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@oneblink/sdk-core/-/sdk-core-10.1.0-beta.9.tgz",
+      "integrity": "sha512-B7DmxHvHk6caphid9gMax7ClDc6DJQFlvnf5FGWQe0UPLHgvTn+zn7radJQVM2viAGhXUAZogsuGAVedEvZH1w==",
       "license": "MIT",
       "dependencies": {
         "morph-expressions": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/oneblink/built-in-data-sources/issues"
   },
   "dependencies": {
-    "@oneblink/sdk": "^13.2.3-beta.7",
-    "@oneblink/sdk-core": "^10.1.0-beta.8",
+    "@oneblink/sdk": "^13.2.3-beta.8",
+    "@oneblink/sdk-core": "^10.1.0-beta.9",
     "jsonwebtoken": "^9.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Requester Checklist

Please only check the items that you have actioned. Do not check items that are not applicable to your PR.

### Implementation

- [ ] Have you tested your implementation locally?
- [ ] If applicable, has an appropriate changelog entry been added? Do not include if you are fixing/changing something that is only in the current release.
- [ ] There are no warnings that have been suppressed unnecessarily
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
- [ ] Have all OneBlink dependency updates been completed (eg apps / apps-react / types etc).
- [ ] Have you ensured this change does not add unwanted dependencies?
- [ ] If this PR contains a refactor, have relevant Jira testing tasks added?
- [ ] Changes that will knowingly make the feature/bug incomplete have been commented with TODO and a description of what needs to be done to finish the feature/bug
- [ ] Any changes made to public APIs have been reflected in the documentation
- [ ] Have you isolated business logic where possible to allow for unit testing?

### Logging and Debugging

- [ ] Are the error messages, if any, informative?
- [ ] Are there enough log events and are they written in a way that allows for easy debugging?
- [ ] "Debugging" code removed
- [ ] Front-end: No erroneous `Console.WriteLines`

### Readability

- [ ] All class, variable, property and method modifiers are provided with the smallest scope possible
- [ ] New files, variables and functions are descriptive/comprehensible and named consistently.
- [ ] There is no dead code (unreachable code)
- [ ] There is no usage of [magic numbers](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
- [ ] There is no commented out code.
- [ ] In hard-to-understand areas, comments exist and describe rationale or reasons for decisions in code

### Security

- [ ] All personal data inputs are checked (for the correct type, length/size, format, and range).
- [ ] No sensitive information is logged or visible in a stacktrace
- [ ] Are authorization and authentication handled correctly?
- [ ] Is (user) input validated, sanitized, and escaped to prevent security attacks such as cross-site scripting or SQL injection?
- [ ] Is data retrieved from external APIs or libraries checked for security issues?
- [ ] Do API endpoints return appropriate status codes

## Reviewer Guide

- It is important that you understand the purpose of the PR.
- You are encouraged to engage with the requestor if you do not understand any of the proposed code changes/additions/deletions.
- Do you, the reviewer, understand what the code does? Do you think a specific expert, like a security expert or a usability expert, should look over the code before it can be accepted?
- Is a framework, API, library, or service used that should not be used? Are there alternatives you could recommend?
- Are there existing hooks/components/functions in the same code base that could be utilised?
- When reviewing tests, attempt to identify missing edge cases that may be relevant to the proposed implementation
- Ensure you check for:
  - Security
  - Scalability
  - Performance
  - Maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no code changes; risk depends on behavior in the new SDK betas, which should be covered by existing tests.
> 
> **Overview**
> Bumps OneBlink platform dependencies to the next beta patch releases: `@oneblink/sdk` **13.2.3-beta.7 → 13.2.3-beta.8** and `@oneblink/sdk-core` **10.1.0-beta.8 → 10.1.0-beta.9**, with `package-lock.json` updated to match.
> 
> There are no application source changes in this PR—only dependency version and lockfile resolution updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e520e5567f10c2cde1fa340855c375f81973398e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->